### PR TITLE
Created Menu Ingredients Modal 

### DIFF
--- a/json_sample_data/menu.json
+++ b/json_sample_data/menu.json
@@ -5,7 +5,8 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$9.99",
     "available": "True",
-    "firebasekey": "-MVvegv2k0wPieOVEFc7"
+    "firebasekey": "-MVvegv2k0wPieOVEFc7",
+    "ingredients": ["-MVxIo-pDIAbUH6jYtSv", "-MVxIvqqqbS2AzG25Ls2", "-MVxJUBooq8-N6V1P0DI", "-MVxJY4fFWYg5BZDzWbe", "-MVxJaCfcjF54RvJqZYH", "-MVxJc6QjwwolEZhQlzZ"]
   },
   "-MVvgW-ax_fs0TChp7i1": {
     "title": "VooDoo Chicken",
@@ -13,7 +14,8 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$12.99",
     "available": "False",
-    "firebasekey": "-MVvgW-ax_fs0TChp7i1"
+    "firebasekey": "-MVvgW-ax_fs0TChp7i1",
+    "ingredients": ["-MVxJgGJNCYH8tqhHoxp", "-MVxIvqqqbS2AzG25Ls2", "-MVxJoQdnYjceeDBA7O1", "-MVxJsN5OwfgAJQgr88V"]
   },
   "-MVvgkAUHzQS45pBEyXp": {
     "title": "Jambalaya",
@@ -21,7 +23,8 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$14.29",
     "available": "True",
-    "firebasekey": "-MVvgkAUHzQS45pBEyXp"
+    "firebasekey": "-MVvgkAUHzQS45pBEyXp",
+    "ingredients": ["-MVxJgGJNCYH8tqhHoxp", "-MVxJugoKnuS-CmIPI4-", "-MVxJsN5OwfgAJQgr88V", "-MVxIo-pDIAbUH6jYtSv", "-MVxJoQdnYjceeDBA7O1", "-MVxJptNSWhQfrCcG9lw", "-MVxJzJFH0RtS3ApJePJ"]
   },
   "-MVvhwqcPvH6_LgwfsEH": {
     "title": "Red Beans and Rice",
@@ -29,7 +32,8 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$8.99",
     "available": "False",
-    "firebasekey": "-MVvhwqcPvH6_LgwfsEH"
+    "firebasekey": "-MVvhwqcPvH6_LgwfsEH",
+    "ingredients": ["-MVxJugoKnuS-CmIPI4-", "-MVxJsN5OwfgAJQgr88V", "-MVxK0suYalyIvOtdMSd"]
   },
   "-MVvj2UFvvjAR3Raku4f": {
     "title": "Crawfish Étouffée",
@@ -37,7 +41,8 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$10.29",
     "available": "True",
-    "firebasekey": "-MVvj2UFvvjAR3Raku4f"
+    "firebasekey": "-MVvj2UFvvjAR3Raku4f",
+    "ingredients": ["-MVxK3R1gXiyIeeuWI4B", "-MVxJsN5OwfgAJQgr88V","-MVxIvqqqbS2AzG25Ls2", "-MVxJc6QjwwolEZhQlzZ", "-MVxJxDtSwnMljDlY3zt", "-MVxK6ox_oGpmr7GnUel"]
   },
   "-MVvkE6dWOzGvEOjuxfq": {
     "title": "Charbroiled Oysters",
@@ -45,6 +50,7 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$14.99",
     "available": "True",
-    "firebasekey": "-MVvkE6dWOzGvEOjuxfq"
+    "firebasekey": "-MVvkE6dWOzGvEOjuxfq",
+    "ingredients": ["-MVxK93udD2YkIRiepnA", "-MVxKAWfdGGTpvtkCUia", "-MVxKBw0GksBUsl90Elz", "-MVxKD7w1yBci7ATP0ag"]
   }
 }

--- a/json_sample_data/menu.json
+++ b/json_sample_data/menu.json
@@ -5,7 +5,7 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$9.99",
     "available": "True",
-    "firebasekey": "-MVvegv2k0wPieOVEFc7",
+    "firebaseKey": "-MVvegv2k0wPieOVEFc7",
     "ingredients": ["-MVxIo-pDIAbUH6jYtSv", "-MVxIvqqqbS2AzG25Ls2", "-MVxJUBooq8-N6V1P0DI", "-MVxJY4fFWYg5BZDzWbe", "-MVxJaCfcjF54RvJqZYH", "-MVxJc6QjwwolEZhQlzZ"]
   },
   "-MVvgW-ax_fs0TChp7i1": {
@@ -14,7 +14,7 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$12.99",
     "available": "False",
-    "firebasekey": "-MVvgW-ax_fs0TChp7i1",
+    "firebaseKey": "-MVvgW-ax_fs0TChp7i1",
     "ingredients": ["-MVxJgGJNCYH8tqhHoxp", "-MVxIvqqqbS2AzG25Ls2", "-MVxJoQdnYjceeDBA7O1", "-MVxJsN5OwfgAJQgr88V"]
   },
   "-MVvgkAUHzQS45pBEyXp": {
@@ -23,7 +23,7 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$14.29",
     "available": "True",
-    "firebasekey": "-MVvgkAUHzQS45pBEyXp",
+    "firebaseKey": "-MVvgkAUHzQS45pBEyXp",
     "ingredients": ["-MVxJgGJNCYH8tqhHoxp", "-MVxJugoKnuS-CmIPI4-", "-MVxJsN5OwfgAJQgr88V", "-MVxIo-pDIAbUH6jYtSv", "-MVxJoQdnYjceeDBA7O1", "-MVxJptNSWhQfrCcG9lw", "-MVxJzJFH0RtS3ApJePJ"]
   },
   "-MVvhwqcPvH6_LgwfsEH": {
@@ -32,7 +32,7 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$8.99",
     "available": "False",
-    "firebasekey": "-MVvhwqcPvH6_LgwfsEH",
+    "firebaseKey": "-MVvhwqcPvH6_LgwfsEH",
     "ingredients": ["-MVxJugoKnuS-CmIPI4-", "-MVxJsN5OwfgAJQgr88V", "-MVxK0suYalyIvOtdMSd"]
   },
   "-MVvj2UFvvjAR3Raku4f": {
@@ -41,7 +41,7 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$10.29",
     "available": "True",
-    "firebasekey": "-MVvj2UFvvjAR3Raku4f",
+    "firebaseKey": "-MVvj2UFvvjAR3Raku4f",
     "ingredients": ["-MVxK3R1gXiyIeeuWI4B", "-MVxJsN5OwfgAJQgr88V","-MVxIvqqqbS2AzG25Ls2", "-MVxJc6QjwwolEZhQlzZ", "-MVxJxDtSwnMljDlY3zt", "-MVxK6ox_oGpmr7GnUel"]
   },
   "-MVvkE6dWOzGvEOjuxfq": {
@@ -50,7 +50,7 @@
     "description": "You're really going to love this dish I made you. If you don't, please lie to my face because I have low self-confidence.",
     "price": "$14.99",
     "available": "True",
-    "firebasekey": "-MVvkE6dWOzGvEOjuxfq",
+    "firebaseKey": "-MVvkE6dWOzGvEOjuxfq",
     "ingredients": ["-MVxK93udD2YkIRiepnA", "-MVxKAWfdGGTpvtkCUia", "-MVxKBw0GksBUsl90Elz", "-MVxKD7w1yBci7ATP0ag"]
   }
 }

--- a/src/javascripts/components/forms/ingredientModal.js
+++ b/src/javascripts/components/forms/ingredientModal.js
@@ -1,0 +1,10 @@
+const menuIngredients = (array) => {
+  document.querySelector('#modal-body').innerHTML = `
+<div id="menu-ingredients">
+</div>`;
+  array.forEach((ingredient) => {
+    document.querySelector('#menu-ingredients').innerHTML += `<p>${ingredient.name}</p> </br>`;
+  });
+};
+
+export default menuIngredients;

--- a/src/javascripts/components/menu/menu.js
+++ b/src/javascripts/components/menu/menu.js
@@ -12,7 +12,7 @@ const showMenuItems = (array) => {
       <p>${item.description}</p>
       <p>${item.price}</p>
       <div class="pb-2">
-        <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="view-menu-ingredients--${item.firebasekey}">View Ingredients</button>
+        <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="view-menu-ingredients--${item.firebaseKey}">View Ingredients</button>
       </div>
     </div>
     </div>`;

--- a/src/javascripts/components/menu/menu.js
+++ b/src/javascripts/components/menu/menu.js
@@ -11,6 +11,7 @@ const showMenuItems = (array) => {
       <h5 class="mt-0">${item.title}</h5>
       <p>${item.description}</p>
       <p>${item.price}</p>
+      <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="view-menu-ingredients--${item.firebasekey}">View Ingredients</button>
     </div>
     </div>`;
   });
@@ -29,6 +30,7 @@ const showLoginMenuItems = (array) => {
       <h5 class="mt-0">${item.title}</h5>
       <p>${item.description}</p>
       <p>${item.price}</p>
+      <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="view-menu-ingredients--${item.firebasekey}">View Ingredients</button>
       <button type="button" class="btn btn-danger" id="delete-menu-item--${item.firebasekey}">Delete</button>
     </div>
     </div>`;

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -8,6 +8,8 @@ import showStaff from '../components/staff/showStaff';
 import { deleteStaff, getStaff } from '../helpers/data/staffData';
 import formModal from '../components/forms/formModal';
 import addIngredientForm from '../components/forms/addIngredientForm';
+import getMenuIngredients from '../helpers/data/menuIngredientsData';
+import menuIngredients from '../components/forms/ingredientModal';
 
 const domEvents = (user) => {
   document.querySelector('body').addEventListener('click', (e) => {
@@ -43,6 +45,14 @@ const domEvents = (user) => {
     if (e.target.id.includes('delete-menu-item')) {
       const firebaseKey = e.target.id.split('--')[1];
       deleteMenuItems(firebaseKey).then((menuArray) => showLoginMenuItems(menuArray));
+    }
+
+    // View Menu Ingredients
+    if (e.target.id.includes('view-menu-ingredients')) {
+      e.preventDefault();
+      const firebaseKey = e.target.id.split('--')[1];
+      getMenuIngredients(firebaseKey).then((menuItem) => menuIngredients(menuItem));
+      formModal('Ingredients');
     }
 
     // Delete Staff

--- a/src/javascripts/helpers/data/ingredientsData.js
+++ b/src/javascripts/helpers/data/ingredientsData.js
@@ -11,6 +11,13 @@ const getIngredients = () => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
+// Get Single Ingredient
+const getSingleIngredient = (firebaseKey) => new Promise((resolve, reject) => {
+  axios.get(`${dbUrl}/ingredients/${firebaseKey}.json`)
+    .then((response) => resolve(response.data))
+    .catch((error) => reject(error));
+});
+
 // Delete Calls
 
 const deleteIngredients = (firebaseKey) => new Promise((resolve, reject) => {
@@ -31,4 +38,6 @@ const createIngredient = (ingredientObject) => new Promise((resolve, reject) => 
     }).catch((error) => reject(error));
 });
 
-export { getIngredients, deleteIngredients, createIngredient };
+export {
+  getIngredients, deleteIngredients, createIngredient, getSingleIngredient
+};

--- a/src/javascripts/helpers/data/menuData.js
+++ b/src/javascripts/helpers/data/menuData.js
@@ -12,6 +12,13 @@ const getMenuItems = () => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
+// Get a single Menu Item
+const getSingleMenuItemIngredients = (firebaseKey) => new Promise((resolve, reject) => {
+  axios.get(`${dbUrl}/menu/${firebaseKey}.json`)
+    .then((response) => resolve(response.data.ingredients))
+    .catch((error) => reject(error));
+});
+
 // DELETE MENU ITEMS
 const deleteMenuItems = (firebasekey, uid) => new Promise((resolve, reject) => {
   axios.delete(`${dbUrl}/menu/${firebasekey}.json`)
@@ -19,4 +26,4 @@ const deleteMenuItems = (firebasekey, uid) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-export { getMenuItems, deleteMenuItems };
+export { getMenuItems, deleteMenuItems, getSingleMenuItemIngredients };

--- a/src/javascripts/helpers/data/menuIngredientsData.js
+++ b/src/javascripts/helpers/data/menuIngredientsData.js
@@ -1,0 +1,12 @@
+import { getSingleIngredient } from './ingredientsData';
+import { getSingleMenuItemIngredients } from './menuData';
+
+const getMenuIngredients = (firebaseKey) => new Promise((resolve, reject) => {
+  getSingleMenuItemIngredients(firebaseKey).then((ingredientsArray) => {
+    const ingredientList = ingredientsArray.map((ingredient) => getSingleIngredient(ingredient));
+
+    Promise.all(ingredientList).then((response) => resolve(response));
+  }).catch((error) => reject(error));
+});
+
+export default getMenuIngredients;


### PR DESCRIPTION
Created Modal to view all Ingredients within a Menu Item

## Description
* Added modal to show all ingredients
* Added DOM event to click on Show Ingredients button
* Added API call to getSingleMenuItem and then return an array of Ingredients and return those. 
* Form Modal is passed array of Ingredients and rendered onto modal

## Related Issue
Fixes #57 

## Motivation and Context
* We want users of our app to be able to see all Ingredients within a Menu Item
* The API calls will allow the modal to by dynamically rendered if a user edits an item's ingredient
* Reusability for showing all ingredients across current and future menu items as added by the user. 

## How Can This Be Tested?
* Within our development netlify link
* Pull down this branch, npm start, and click on Menu on navbar. Click 'View Menu Ingredients' button.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
