### PR TITLE
Create Menu Ingredient Modal

### DIFF
--- a/src/javascripts/components/forms/createMenuItemForm.js
+++ b/src/javascripts/components/forms/createMenuItemForm.js
@@ -1,3 +1,5 @@
+import selectIngredients from '../menu/selectIngredient';
+
 const createMenuItemForm = () => {
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#view').innerHTML = '';
@@ -28,6 +30,8 @@ const createMenuItemForm = () => {
   </div>
   <button type="submit" id="create-menu-item" class="btn btn-primary">Create Menu Item</button>
 </form>`;
+
+  selectIngredients();
 };
 
 export default createMenuItemForm;

--- a/src/javascripts/components/menu/menu.js
+++ b/src/javascripts/components/menu/menu.js
@@ -12,7 +12,7 @@ const showMenuItems = (array) => {
       <p>${item.description}</p>
       <p>${item.price}</p>
       <div class="pb-2">
-        <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="view-menu-ingredients--${item.firebaseKey}">View Ingredients</button>
+      <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="view-menu-ingredients--${item.firebaseKey}">View Ingredients</button>
       </div>
     </div>
     </div>`;

--- a/src/javascripts/components/menu/selectIngredient.js
+++ b/src/javascripts/components/menu/selectIngredient.js
@@ -3,30 +3,27 @@ import 'firebase/auth';
 import { getIngredients } from '../../helpers/data/ingredientsData';
 
 const selectIngredients = () => {
-  let domstring = `<ul>
+  let domString = `<ul>
     <li class="dropdown">
       <a href="#" data-toggle="dropdown" class="dropdown-toggle">Select Ingredients<b class="caret"></b></a>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu" id="ingredients-list">
             <li>
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox"> Random Ingredient
-                    </label>
-                </div>
-            </li>
-        </ul>
-    </li>
-  </ul>`;
+            </li>`;
 
   getIngredients().then((ingredientsArray) => {
-    ingredientsArray.foreach((ingredient) => {
-      domstring += `<input type="checkbox">${ingredient.title}`;
+    ingredientsArray.forEach((ingredient) => {
+      domString += `<li>
+      <div class="checkbox">
+          <label>
+              <input type="checkbox" name="${ingredient.name}" class="ingredient-check" id="ingredientCheckbox${ingredient.name}" value="${ingredient.firebaseKey}"> ${ingredient.name}
+          </label>
+      </div>
+  </li>`;
     });
+    domString += '</ul> </li> </ul>';
+
+    document.querySelector('#select-ingredients').innerHTML = domString;
   });
-
-  domstring += '</select>';
-
-  document.querySelector('#select-ingredients').innerHTML = domstring;
 };
 
 export default selectIngredients;

--- a/src/javascripts/components/menu/selectIngredient.js
+++ b/src/javascripts/components/menu/selectIngredient.js
@@ -1,0 +1,32 @@
+// import firebase from 'firebase/app';
+import 'firebase/auth';
+import { getIngredients } from '../../helpers/data/ingredientsData';
+
+const selectIngredients = () => {
+  let domstring = `<ul>
+    <li class="dropdown">
+      <a href="#" data-toggle="dropdown" class="dropdown-toggle">Select Ingredients<b class="caret"></b></a>
+        <ul class="dropdown-menu">
+            <li>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox"> Random Ingredient
+                    </label>
+                </div>
+            </li>
+        </ul>
+    </li>
+  </ul>`;
+
+  getIngredients().then((ingredientsArray) => {
+    ingredientsArray.foreach((ingredient) => {
+      domstring += `<input type="checkbox">${ingredient.title}`;
+    });
+  });
+
+  domstring += '</select>';
+
+  document.querySelector('#select-ingredients').innerHTML = domstring;
+};
+
+export default selectIngredients;

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -28,6 +28,7 @@ const domEvents = (user) => {
         deleteIngredients(firebaseKey).then((ingredients) => showLoginIngredients(ingredients));
       }
     }
+
     // Create Ingredient
     if (e.target.id.includes('addIngredient')) {
       e.preventDefault();
@@ -85,11 +86,18 @@ const domEvents = (user) => {
     // SUBMIT CREATE MENU ITEM
     if (e.target.id.includes('create-menu-item')) {
       e.preventDefault();
+      const checkBoxes = [];
+      const markedCheckbox = document.querySelectorAll('input[type="checkbox"]:checked');
+      markedCheckbox.forEach((checkbox) => {
+        if (checkbox.value !== 'on') {
+          checkBoxes.push(checkbox.value);
+        }
+      });
       const itemObject = {
         image: document.querySelector('#itemImage').value,
         title: document.querySelector('#itemTitle').value,
         description: document.querySelector('#itemDescription').value,
-        ingredients: document.querySelector('#select-ingredients').value,
+        ingredients: checkBoxes,
         price: document.querySelector('#itemPrice').value,
         available: document.querySelector('#available').checked
       };

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -89,6 +89,7 @@ const domEvents = (user) => {
         image: document.querySelector('#itemImage').value,
         title: document.querySelector('#itemTitle').value,
         description: document.querySelector('#itemDescription').value,
+        ingredients: document.querySelector('#select-ingredients').value,
         price: document.querySelector('#itemPrice').value,
         available: document.querySelector('#available').checked
       };


### PR DESCRIPTION
Added feature for adding ingredients when creating new Menu Item

## Description
* When a user creates a new menu item, a checkbox list pops up with all available ingredients
* A user may select as many ingredients as desired for that menu item
* Upon submission, the new menu item is created, and the user may click the 'view ingredients' button to see the applied ingredient list

## Related Issue
Fixes #57 

## Motivation and Context
* Instead of users having to come up with ingredients, they may simply use the ingredients that are available. 

## How Can This Be Tested?
git checkout cw-create-menu-ingredient, click on 'Menu' in the navbar, click 'Add new menu item'. Type in the required fields, and on the drop down select applicable ingredients. A new menu item should render, click 'view ingredients'

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
