### PR TITLE
Edit Ingredient Feature

### DIFF
--- a/src/javascripts/components/forms/editIngredientForm.js
+++ b/src/javascripts/components/forms/editIngredientForm.js
@@ -1,0 +1,11 @@
+const editIngredientForm = (firebaseKey) => {
+  document.querySelector('#modal-body').innerHTML = `<form id="edit-Ingredient-Form" class="mb-4">
+<div class="form-group">
+  <label for="ingredientName">Ingredient: </label>
+  <input type="text" class="form-control" id="newIngredientName" placeholder="Ingredient Name" required>
+</div>
+<button type="submit" id="submitEditIngredient^^${firebaseKey}" class="btn btn-primary">Submit Ingredient</button>
+</form>`;
+};
+
+export default editIngredientForm;

--- a/src/javascripts/components/ingredients/showIngredients.js
+++ b/src/javascripts/components/ingredients/showIngredients.js
@@ -24,6 +24,7 @@ const showLoginIngredients = (array) => {
   array.forEach((item) => {
     document.querySelector('#ingredients-list').innerHTML += `
     <li class="list-group-item text-capitalize">${item.name} </br>
+    <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="editIngredient^^${item.firebaseKey}">Edit</button>
     <button type="button" class="btn btn-danger" id="deleteIngredient^^${item.firebaseKey}">Delete</button></li>`;
   });
 };

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -1,4 +1,4 @@
-import { createIngredient, deleteIngredients } from '../helpers/data/ingredientsData';
+import { createIngredient, deleteIngredients, updateIngredient } from '../helpers/data/ingredientsData';
 import { showLoginIngredients } from '../components/ingredients/showIngredients';
 import { showLoginMenuItems } from '../components/menu/menu';
 import { createReservation, deleteReservation } from '../helpers/data/reservationData';
@@ -13,6 +13,7 @@ import getMenuIngredients from '../helpers/data/menuIngredientsData';
 import menuIngredients from '../components/forms/ingredientModal';
 import addReservationForm from '../components/forms/addReservationForm';
 import addStaffForm from '../components/forms/addStaffForm';
+import editIngredientForm from '../components/forms/editIngredientForm';
 
 const domEvents = (user) => {
   document.querySelector('body').addEventListener('click', (e) => {
@@ -42,6 +43,26 @@ const domEvents = (user) => {
         name: document.querySelector('#ingredientName').value
       };
       createIngredient(ingredientObject).then((ingredients) => showLoginIngredients(ingredients));
+      $('#formModal').modal('toggle');
+    }
+
+    // Edit Ingredient
+    if (e.target.id.includes('editIngredient')) {
+      e.preventDefault();
+      const firebaseKey = e.target.id.split('^^')[1];
+      formModal('Edit Ingredient');
+      editIngredientForm(firebaseKey);
+    }
+
+    // Submit on Edit Ingredient Form
+    if (e.target.id.includes('submitEditIngredient')) {
+      e.preventDefault();
+      const firebaseKey = e.target.id.split('^^')[1];
+      const ingredientObject = {
+        firebaseKey,
+        name: document.querySelector('#newIngredientName').value
+      };
+      updateIngredient(firebaseKey, ingredientObject).then((ingredients) => showLoginIngredients(ingredients));
       $('#formModal').modal('toggle');
     }
 

--- a/src/javascripts/helpers/data/ingredientsData.js
+++ b/src/javascripts/helpers/data/ingredientsData.js
@@ -37,6 +37,14 @@ const createIngredient = (ingredientObject) => new Promise((resolve, reject) => 
     }).catch((error) => reject(error));
 });
 
+// Update Ingredients
+const updateIngredient = (firebaseKey, ingredientObject) => new Promise((resolve, reject) => {
+  axios.patch(`${dbUrl}/ingredients/${firebaseKey}.json`, ingredientObject)
+    .then(() => getIngredients())
+    .then((ingredientsArray) => resolve(ingredientsArray))
+    .catch((error) => reject(error));
+});
+
 export {
-  getIngredients, deleteIngredients, createIngredient, getSingleIngredient
+  getIngredients, deleteIngredients, createIngredient, getSingleIngredient, updateIngredient
 };


### PR DESCRIPTION
Added Feature to Edit an Ingredient Name

## Description
* A user can go to the list of Ingredients, click edit, and then change the name of an ingredient. 

## Related Issue
Fixes #28 

## Motivation and Context
* We want our users to be able to update the ingredients as needed.

## How Can This Be Tested?
* pull down cw-editIngredient branch, npm start, click on 'Ingredients' in the navbar. Find an ingredient, and click 'Edit'. Type in a new name and submit, the app should update with the new ingredient. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
