### PR TITLE
removed available from domEvents object

### DIFF
--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -132,7 +132,6 @@ const domEventListeners = (e) => {
       description: document.querySelector('#itemDescription').value,
       ingredients: checkBoxes,
       price: document.querySelector('#itemPrice').value,
-      available: document.querySelector('#available').checked
     };
     createMenuItems(itemObject).then((menuArray) => showLoginMenuItems(menuArray));
   }
@@ -161,7 +160,6 @@ const domEventListeners = (e) => {
       description: document.querySelector('#itemDescription').value,
       ingredients: checkBoxes,
       price: document.querySelector('#itemPrice').value,
-      available: document.querySelector('#available').checked
     };
     updateMenuItems(firebaseKey, itemObject).then((menuArray) => showLoginMenuItems(menuArray));
   }


### PR DESCRIPTION
## Description
removed the available key value pair from the create and edit objects in domevents

## Related Issue
#78 

## Motivation and Context
For the create menu item form to work again without errors

## How Can This Be Tested?
click on add menu item button and create a new item. Form will submit without an available input.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
