### PR TITLE
Bug Fix: Ingredient Default Value

### DIFF
--- a/src/javascripts/components/forms/editIngredientForm.js
+++ b/src/javascripts/components/forms/editIngredientForm.js
@@ -1,10 +1,10 @@
-const editIngredientForm = (firebaseKey) => {
+const editIngredientForm = (ingredient) => {
   document.querySelector('#modal-body').innerHTML = `<form id="edit-Ingredient-Form" class="mb-4">
 <div class="form-group">
   <label for="ingredientName">Ingredient: </label>
-  <input type="text" class="form-control" id="newIngredientName" placeholder="Ingredient Name" required>
+  <input type="text" class="form-control" id="newIngredientName" value="${ingredient.name}" required>
 </div>
-<button type="submit" id="submitEditIngredient^^${firebaseKey}" class="btn btn-primary">Submit Ingredient</button>
+<button type="submit" id="submitEditIngredient^^${ingredient.firebaseKey}" class="btn btn-primary">Submit Ingredient</button>
 </form>`;
 };
 

--- a/src/javascripts/components/ingredients/showIngredients.js
+++ b/src/javascripts/components/ingredients/showIngredients.js
@@ -24,7 +24,7 @@ const showLoginIngredients = (array) => {
   array.forEach((item) => {
     document.querySelector('#ingredients-list').innerHTML += `
     <li class="list-group-item text-capitalize">${item.name} </br>
-    <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="editIngredient^^${item.firebaseKey}">Edit</button>
+    <button type="button" class="btn btn-info" data-toggle="modal" data-target="#formModal" id="editIngredient--${item.firebaseKey}">Edit</button>
     <button type="button" class="btn btn-danger" id="deleteIngredient--${item.firebaseKey}">Delete</button></li>`;
   });
 };

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -1,4 +1,6 @@
-import { createIngredient, deleteIngredients, updateIngredient } from '../helpers/data/ingredientsData';
+import {
+  createIngredient, deleteIngredients, getSingleIngredient, updateIngredient
+} from '../helpers/data/ingredientsData';
 import { showLoginIngredients } from '../components/ingredients/showIngredients';
 import { showLoginMenuItems } from '../components/menu/menu';
 import {
@@ -60,7 +62,7 @@ const domEvents = (user) => {
       e.preventDefault();
       const firebaseKey = e.target.id.split('^^')[1];
       formModal('Edit Ingredient');
-      editIngredientForm(firebaseKey);
+      getSingleIngredient(firebaseKey).then((ingredient) => editIngredientForm(ingredient));
     }
 
     // Submit on Edit Ingredient Form


### PR DESCRIPTION
Fixed a bug where editing ingredients did not have the default value. 

## Description
* Passed the default ingredient name to the edit ingredient form. 

## Related Issue
Fixes #75 

## Motivation and Context
* This will allow the user to see the ingredient that they are editing when the modal pops up. 

## How Can This Be Tested?
pull down this branch, npm start. Click 'ingredients' on the navbar, and hit edit on any ingredient. 
The name of the ingredient should populate within the text field. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
