### PR TITLE
Bug Fix: Edit Ingredient Form

### DIFF
--- a/src/javascripts/components/forms/editIngredientForm.js
+++ b/src/javascripts/components/forms/editIngredientForm.js
@@ -4,7 +4,7 @@ const editIngredientForm = (ingredient) => {
   <label for="ingredientName">Ingredient: </label>
   <input type="text" class="form-control" id="newIngredientName" value="${ingredient.name}" required>
 </div>
-<button type="submit" id="submitEditIngredient^^${ingredient.firebaseKey}" class="btn btn-primary">Submit Ingredient</button>
+<button type="submit" id="submitEditIngredient--${ingredient.firebaseKey}" class="btn btn-primary">Submit Ingredient</button>
 </form>`;
 };
 


### PR DESCRIPTION
Fixed a bug where editing ingredient form did not submit.

## Description
* Refactored the submit form button to take in appropriate firebaseKey. 

## Related Issue
Fixes #75 

## Motivation and Context
* This will allow the user to submit the edited ingredient.

## How Can This Be Tested?
pull down this branch, npm start. Click 'ingredients' on the navbar, and hit edit on any ingredient. 
The name of the ingredient should populate within the text field. Click submit and the ingredient will update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)