### PR TITLE
Filter: Menu Items 

### DIFF
--- a/src/javascripts/components/domBuilder.js
+++ b/src/javascripts/components/domBuilder.js
@@ -4,6 +4,7 @@ const domBuilder = () => {
   <div id="main-container">
     <div class="align-text-center my-3" id="stage"></div>
     <div id="form-container"></div>
+    <div id="filter-container"></div>
     <div id="view"></div>
     <div id="modal-container"></div>
   </div>`;

--- a/src/javascripts/components/forms/createMenuItemForm.js
+++ b/src/javascripts/components/forms/createMenuItemForm.js
@@ -3,7 +3,7 @@ import selectIngredients from '../menu/selectIngredient';
 const createMenuItemForm = () => {
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#view').innerHTML = '';
-
+  document.querySelector('#filter-container').innerHTML = '';
   document.querySelector('#form-container').innerHTML = `
   <form id="create-menu-form" class="mb-4">
   <div class="form-group">
@@ -26,7 +26,6 @@ const createMenuItemForm = () => {
   </div>
   <button type="submit" id="create-menu-item" class="btn btn-primary">Create Menu Item</button>
 </form>`;
-
   selectIngredients();
 };
 

--- a/src/javascripts/components/forms/editMenuItems.js
+++ b/src/javascripts/components/forms/editMenuItems.js
@@ -1,4 +1,4 @@
-import getMenuIngredients from '../../helpers/data/menuIngredientsData';
+import { getMenuIngredients } from '../../helpers/data/menuIngredientsData';
 import selectIngredients from '../menu/selectIngredient';
 
 const editMenuItemForm = (menuObject) => {

--- a/src/javascripts/components/ingredients/showIngredients.js
+++ b/src/javascripts/components/ingredients/showIngredients.js
@@ -2,6 +2,7 @@ const showIngredients = (array) => {
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#modal-container').innerHTML = '';
   document.querySelector('#form-container').innerHTML = '';
+  document.querySelector('#filter-container').innerHTML = '';
   document.querySelector('#view').innerHTML = `<div class="card mt-2 ingredients" style="width: 18rem;">
   <ul class="list-group list-group-flush" id="ingredients-list">
   </ul>
@@ -15,6 +16,7 @@ const showIngredients = (array) => {
 const showLoginIngredients = (array) => {
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '';
+  document.querySelector('#filter-container').innerHTML = '';
   document.querySelector('#form-container').innerHTML = '';
   document.querySelector('#stage').innerHTML = '<button type="button" class="btn btn-info mt-2" data-toggle="modal" data-target="#formModal" id="addIngredient">Add a new ingredient</button>';
   document.querySelector('#view').innerHTML = `<div class="card mt-2 ingredients" style="width: 18rem;">

--- a/src/javascripts/components/menu/filterMenu.js
+++ b/src/javascripts/components/menu/filterMenu.js
@@ -1,30 +1,18 @@
-import { getIngredients } from '../../helpers/data/ingredientsData';
-
-const filterMenu = (array = []) => {
-  let domString = `<ul>
+const filterMenu = () => {
+  const domString = `<ul>
     <li class="dropdown">
-      <a href="#" data-toggle="dropdown" class="dropdown-toggle">Select Ingredients<b class="caret"></b></a>
+      <a href="#" data-toggle="dropdown" class="dropdown-toggle">Filter by Ingredients<b class="caret"></b></a>
         <ul class="dropdown-menu" id="filter-ingredients">
             <li>
-            </li>`;
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" name="ingredient" class="ingredient-check" id="filterCheckbox" value="ingredient">
+                </label>
+              </div>
+            </li>
+        </ul>`;
 
-  getIngredients().then((ingredientsArray) => {
-    ingredientsArray.forEach((ingredient) => {
-      if (array.includes(ingredient.firebaseKey)) {
-        domString += `<li>
-        <div class="checkbox">
-            <label>
-                <input type="checkbox" name="${ingredient.name}" class="ingredient-check" id="ingredientCheckbox${ingredient.name}" value="${ingredient.firebaseKey}"> ${ingredient.name}
-            </label>
-        </div>
-    </li>`;
-      }
-    });
-
-    domString += '</ul> </li> </ul>';
-
-    document.querySelector('#form-container').innerHTML = domString;
-  });
+  document.querySelector('#form-container').innerHTML = domString;
 };
 
 export default filterMenu;

--- a/src/javascripts/components/menu/filterMenu.js
+++ b/src/javascripts/components/menu/filterMenu.js
@@ -1,0 +1,30 @@
+import { getIngredients } from '../../helpers/data/ingredientsData';
+
+const filterMenu = (array = []) => {
+  let domString = `<ul>
+    <li class="dropdown">
+      <a href="#" data-toggle="dropdown" class="dropdown-toggle">Select Ingredients<b class="caret"></b></a>
+        <ul class="dropdown-menu" id="filter-ingredients">
+            <li>
+            </li>`;
+
+  getIngredients().then((ingredientsArray) => {
+    ingredientsArray.forEach((ingredient) => {
+      if (array.includes(ingredient.firebaseKey)) {
+        domString += `<li>
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" name="${ingredient.name}" class="ingredient-check" id="ingredientCheckbox${ingredient.name}" value="${ingredient.firebaseKey}"> ${ingredient.name}
+            </label>
+        </div>
+    </li>`;
+      }
+    });
+
+    domString += '</ul> </li> </ul>';
+
+    document.querySelector('#form-container').innerHTML = domString;
+  });
+};
+
+export default filterMenu;

--- a/src/javascripts/components/menu/filterMenu.js
+++ b/src/javascripts/components/menu/filterMenu.js
@@ -1,18 +1,29 @@
+import { getIngredients } from '../../helpers/data/ingredientsData';
+
 const filterMenu = () => {
-  const domString = `<ul>
+  let domString = `<ul>
     <li class="dropdown">
       <a href="#" data-toggle="dropdown" class="dropdown-toggle">Filter by Ingredients<b class="caret"></b></a>
-        <ul class="dropdown-menu" id="filter-ingredients">
+        <ul class="dropdown-menu" id="ingredients-list">
+        <div>
+        <input type="submit" name="submit" value="Submit" id="filterMenuSubmit" />
+        </div> 
             <li>
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" name="ingredient" class="ingredient-check" id="filterCheckbox" value="ingredient">
-                </label>
-              </div>
-            </li>
-        </ul>`;
+            </li>`;
 
-  document.querySelector('#form-container').innerHTML = domString;
+  getIngredients().then((ingredientsArray) => {
+    ingredientsArray.forEach((ingredient) => {
+      domString += `<li>
+      <div class="checkbox">
+          <label>
+              <input type="checkbox" name="${ingredient.name}" class="ingredient-check" id="filterIngredientCheckbox${ingredient.name}" value="${ingredient.firebaseKey}"> ${ingredient.name}
+          </label>
+      </div>
+  </li>`;
+    });
+    domString += '</ul> </li> </ul>';
+    document.querySelector('#filter-container').innerHTML = domString;
+  });
 };
 
 export default filterMenu;

--- a/src/javascripts/components/menu/filterSubmit.js
+++ b/src/javascripts/components/menu/filterSubmit.js
@@ -1,0 +1,12 @@
+import { getFilterMenuItems } from '../../helpers/data/menuIngredientsData';
+import { showLoginMenuItems } from './menu';
+
+const filterSubmit = (checkBoxes) => {
+  document.querySelector('body').addEventListener('click', (e) => {
+    if (e.target.id.includes('filterMenuSubmit')) {
+      getFilterMenuItems(checkBoxes).then((menuArray) => showLoginMenuItems(menuArray));
+    }
+  });
+};
+
+export default filterSubmit;

--- a/src/javascripts/components/menu/menu.js
+++ b/src/javascripts/components/menu/menu.js
@@ -5,6 +5,7 @@ const showMenuItems = (array) => {
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#modal-container').innerHTML = '';
+  document.querySelector('#form-container').innerHTML = '';
 
   array.forEach((item) => {
     document.querySelector('#view').innerHTML += `<div class="media pb-2">
@@ -26,6 +27,7 @@ const showLoginMenuItems = (array) => {
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '<button type="button" class="btn btn-light" id="add-menu-btn">Add Menu Item</button>';
   document.querySelector('#modal-container').innerHTML = '';
+  document.querySelector('#form-container').innerHTML = '';
 
   array.forEach((item) => {
     document.querySelector('#view').innerHTML += `<div class="media">

--- a/src/javascripts/components/menu/menu.js
+++ b/src/javascripts/components/menu/menu.js
@@ -1,8 +1,7 @@
+import filterMenu from './filterMenu';
+
 const showMenuItems = (array) => {
-  document.querySelector('#form-container').innerHTML = `<form class="form-inline my-2 my-lg-0">
-  <input class="form-control mr-sm-2" id="menuFilter2" type="search" placeholder="Filter by Ingredient" aria-label="Search">
-  <button class="btn btn-outline-success id="submitMenuFilter2" my-2 my-sm-0" type="submit">Filter</button>
-</form>`;
+  filterMenu();
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#modal-container').innerHTML = '';
@@ -23,10 +22,7 @@ const showMenuItems = (array) => {
 };
 
 const showLoginMenuItems = (array) => {
-  document.querySelector('#form-container').innerHTML = `<form class="form-inline my-2 my-lg-0">
-  <input class="form-control mr-sm-2" id="menuFilter" type="search" placeholder="Filter by Ingredient" aria-label="Search">
-  <button class="btn btn-outline-success id="submitMenuFilter" my-2 my-sm-0" type="submit">Filter</button>
-</form>`;
+  filterMenu();
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '<button type="button" class="btn btn-light" id="add-menu-btn">Add Menu Item</button>';
   document.querySelector('#modal-container').innerHTML = '';

--- a/src/javascripts/components/menu/menu.js
+++ b/src/javascripts/components/menu/menu.js
@@ -1,5 +1,8 @@
 const showMenuItems = (array) => {
-  document.querySelector('#form-container').innerHTML = '';
+  document.querySelector('#form-container').innerHTML = `<form class="form-inline my-2 my-lg-0">
+  <input class="form-control mr-sm-2" id="menuFilter2" type="search" placeholder="Filter by Ingredient" aria-label="Search">
+  <button class="btn btn-outline-success id="submitMenuFilter2" my-2 my-sm-0" type="submit">Filter</button>
+</form>`;
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#modal-container').innerHTML = '';
@@ -20,7 +23,10 @@ const showMenuItems = (array) => {
 };
 
 const showLoginMenuItems = (array) => {
-  document.querySelector('#form-container').innerHTML = '';
+  document.querySelector('#form-container').innerHTML = `<form class="form-inline my-2 my-lg-0">
+  <input class="form-control mr-sm-2" id="menuFilter" type="search" placeholder="Filter by Ingredient" aria-label="Search">
+  <button class="btn btn-outline-success id="submitMenuFilter" my-2 my-sm-0" type="submit">Filter</button>
+</form>`;
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '<button type="button" class="btn btn-light" id="add-menu-btn">Add Menu Item</button>';
   document.querySelector('#modal-container').innerHTML = '';

--- a/src/javascripts/components/menu/selectIngredient.js
+++ b/src/javascripts/components/menu/selectIngredient.js
@@ -2,6 +2,7 @@ import 'firebase/auth';
 import { getIngredients } from '../../helpers/data/ingredientsData';
 
 const selectIngredients = (array = []) => {
+  document.querySelector('#filter-container').innerHTML = '';
   let domString = `<ul>
     <li class="dropdown">
       <a href="#" data-toggle="dropdown" class="dropdown-toggle">Select Ingredients<b class="caret"></b></a>

--- a/src/javascripts/components/reservations/reservations.js
+++ b/src/javascripts/components/reservations/reservations.js
@@ -2,6 +2,7 @@ const showReservations = (array) => {
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#form-container').innerHTML = '';
+  document.querySelector('#filter-container').innerHTML = '';
 
   array.forEach((item) => {
     document.querySelector('#view').innerHTML += `
@@ -18,6 +19,7 @@ const showReservations = (array) => {
 const showLoginReservations = (array) => {
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#form-container').innerHTML = '';
+  document.querySelector('#filter-container').innerHTML = '';
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '<button type="button" class="btn btn-info mt-2" data-toggle="modal" data-target="#formModal" id="addReservation">Add a New Reservation</button>';
   array.forEach((item) => {

--- a/src/javascripts/components/seating/seating.js
+++ b/src/javascripts/components/seating/seating.js
@@ -1,5 +1,6 @@
 const showSeating = (array) => {
   document.querySelector('#stage').innerHTML = '';
+  document.querySelector('#filter-container').innerHTML = '';
   document.querySelector('#form-container').innerHTML = '';
   document.querySelector('#view').innerHTML = `<div class="card mt-2" style="width: 18rem;">
   <ul class="list-group list-group-flush" id="ingredients-list">

--- a/src/javascripts/components/staff/showStaff.js
+++ b/src/javascripts/components/staff/showStaff.js
@@ -1,6 +1,7 @@
 const showStaff = (staffArray, user) => {
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#stage').innerHTML = '';
+  document.querySelector('#filter-container').innerHTML = '';
   document.querySelector('#form-container').innerHTML = '';
   document.querySelector('#stage').innerHTML = '<button type="button" class="btn btn-info mt-2" data-toggle="modal" data-target="#formModal" id="add-staff-member">Add Staff Member</button>';
   document.querySelector('#view').innerHTML = `

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -19,7 +19,7 @@ import {
 } from '../helpers/data/staffData';
 import formModal from '../components/forms/formModal';
 import addIngredientForm from '../components/forms/addIngredientForm';
-import getMenuIngredients from '../helpers/data/menuIngredientsData';
+import { getMenuIngredients } from '../helpers/data/menuIngredientsData';
 import menuIngredients from '../components/forms/ingredientModal';
 import addReservationForm from '../components/forms/addReservationForm';
 import addStaffForm from '../components/forms/addStaffForm';
@@ -27,6 +27,7 @@ import editIngredientForm from '../components/forms/editIngredientForm';
 import updateStaffForm from '../components/forms/updateStaffForm';
 import editReservationForm from '../components/forms/editReservationForm';
 import editMenuItemForm from '../components/forms/editMenuItems';
+import filterSubmit from '../components/menu/filterSubmit';
 // import filterMenu from '../components/menu/filterMenu';
 
 const domEventListeners = (e) => {
@@ -93,7 +94,6 @@ const domEventListeners = (e) => {
   }
 
   // SHOW FILTER MENU ITEMS DROPDOWN
-  // filterMenu();
 
   // CLICK EVENT FOR SHOWING MODAL FORM FOR EDITING A RESERVATION
   if (e.target.id.includes('edit-res-btn')) {
@@ -139,7 +139,12 @@ const domEventListeners = (e) => {
       ingredients: checkBoxes,
       price: document.querySelector('#itemPrice').value,
     };
-    createMenuItems(itemObject).then((menuArray) => showLoginMenuItems(menuArray));
+    if (itemObject.ingredients.length < 1) {
+      // eslint-disable-next-line no-alert
+      window.confirm('Please add at least 1 Ingredient');
+    } else {
+      createMenuItems(itemObject).then((menuArray) => showLoginMenuItems(menuArray));
+    }
   }
 
   // SHOW FORM TO EDIT MENU ITEM
@@ -147,6 +152,15 @@ const domEventListeners = (e) => {
     const firebaseKey = e.target.id.split('--')[1];
     formModal('Edit Menu');
     getSingleMenuItem(firebaseKey).then((menuObject) => editMenuItemForm(menuObject));
+  }
+  // Filter Menu Items
+  if (e.target.id.includes('filterIngredientCheckbox')) {
+    const checkBoxes = [];
+    const markedCheckbox = document.querySelectorAll('input[type="checkbox"]:checked');
+    markedCheckbox.forEach((checkbox) => {
+      checkBoxes.push(checkbox.value);
+    });
+    filterSubmit(checkBoxes);
   }
 
   // SUBMIT EDIT MENU ITEM

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -28,7 +28,6 @@ import updateStaffForm from '../components/forms/updateStaffForm';
 import editReservationForm from '../components/forms/editReservationForm';
 import editMenuItemForm from '../components/forms/editMenuItems';
 import filterSubmit from '../components/menu/filterSubmit';
-// import filterMenu from '../components/menu/filterMenu';
 
 const domEventListeners = (e) => {
   const user = firebase.auth().currentUser;
@@ -93,8 +92,6 @@ const domEventListeners = (e) => {
     formModal('Ingredients');
   }
 
-  // SHOW FILTER MENU ITEMS DROPDOWN
-
   // CLICK EVENT FOR SHOWING MODAL FORM FOR EDITING A RESERVATION
   if (e.target.id.includes('edit-res-btn')) {
     const firebaseKey = e.target.id.split('--')[1];
@@ -153,6 +150,7 @@ const domEventListeners = (e) => {
     formModal('Edit Menu');
     getSingleMenuItem(firebaseKey).then((menuObject) => editMenuItemForm(menuObject));
   }
+
   // Filter Menu Items
   if (e.target.id.includes('filterIngredientCheckbox')) {
     const checkBoxes = [];
@@ -181,7 +179,12 @@ const domEventListeners = (e) => {
       ingredients: checkBoxes,
       price: document.querySelector('#itemPrice').value,
     };
-    updateMenuItems(firebaseKey, itemObject).then((menuArray) => showLoginMenuItems(menuArray));
+    if (itemObject.ingredients.length < 1) {
+      // eslint-disable-next-line no-alert
+      window.confirm('Please add at least 1 Ingredient');
+    } else {
+      updateMenuItems(firebaseKey, itemObject).then((menuArray) => showLoginMenuItems(menuArray));
+    }
   }
 
   // CREATE RESERVATION FORM POPUP

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -93,6 +93,7 @@ const domEventListeners = (e) => {
   }
 
   // SHOW FILTER MENU ITEMS DROPDOWN
+  // filterMenu();
 
   // CLICK EVENT FOR SHOWING MODAL FORM FOR EDITING A RESERVATION
   if (e.target.id.includes('edit-res-btn')) {

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -117,6 +117,15 @@ const domEvents = (user) => {
       updateMenuItems(firebaseKey, itemObject).then((menuArray) => showLoginMenuItems(menuArray));
     }
 
+    // FILTER MENU ITEMS
+    if (e.target.id.includes('submitMenuFilter')) {
+      const searchString = document.querySelector('#menuFilter').value;
+      const filteredMenu = Array.filter((menu) => menu.ingredients.includes(searchString));
+      console.warn(searchString);
+      console.warn(filteredMenu);
+      // getMenuItems(filteredMenu);
+    }
+
     // CREATE RESERVATION FORM POPUP
     if (e.target.id.includes('addReservation')) {
       e.preventDefault();

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -27,6 +27,7 @@ import editIngredientForm from '../components/forms/editIngredientForm';
 import updateStaffForm from '../components/forms/updateStaffForm';
 import editReservationForm from '../components/forms/editReservationForm';
 import editMenuItemForm from '../components/forms/editMenuItems';
+// import filterMenu from '../components/menu/filterMenu';
 
 const domEventListeners = (e) => {
   const user = firebase.auth().currentUser;
@@ -91,14 +92,7 @@ const domEventListeners = (e) => {
     formModal('Ingredients');
   }
 
-  // FILTER MENU ITEMS
-  if (e.target.id.includes('submitMenuFilter')) {
-    const searchString = document.querySelector('#menuFilter').value;
-    const filteredMenu = Array.filter((menu) => menu.ingredients.includes(searchString));
-    console.warn(searchString);
-    console.warn(filteredMenu);
-    // getMenuItems(filteredMenu);
-  }
+  // SHOW FILTER MENU ITEMS DROPDOWN
 
   // CLICK EVENT FOR SHOWING MODAL FORM FOR EDITING A RESERVATION
   if (e.target.id.includes('edit-res-btn')) {

--- a/src/javascripts/helpers/data/menuIngredientsData.js
+++ b/src/javascripts/helpers/data/menuIngredientsData.js
@@ -1,5 +1,5 @@
 import { getSingleIngredient } from './ingredientsData';
-import { getSingleMenuItemIngredients } from './menuData';
+import { getMenuItems, getSingleMenuItemIngredients } from './menuData';
 
 const getMenuIngredients = (firebaseKey) => new Promise((resolve, reject) => {
   getSingleMenuItemIngredients(firebaseKey).then((ingredientsArray) => {
@@ -9,4 +9,11 @@ const getMenuIngredients = (firebaseKey) => new Promise((resolve, reject) => {
   }).catch((error) => reject(error));
 });
 
-export default getMenuIngredients;
+const getFilterMenuItems = (ingredientArray) => new Promise((resolve, reject) => {
+  getMenuItems().then((menuArray) => {
+    const result = menuArray.filter((item) => ingredientArray.every((ingredient) => item.ingredients.includes(ingredient)));
+    resolve(result);
+  }).catch((error) => reject(error));
+});
+
+export { getMenuIngredients, getFilterMenuItems };


### PR DESCRIPTION
New Feature: Filter Menu Items by ingredients

## Description
* A user may now navigate to Menu Items, click 'Filter by Ingredients', select a list of ingredients, and filter down to Menu Items that contain all selected ingredients. 

## Related Issue
Fixes #83 

## Motivation and Context
* We have a very robust menu, and we want our users to be able view our website and see if we offer menu items that meet their exact cravings by available ingredients. 
* Also require new menu items to have at least 1 ingredient added to prevent any bugs on the filter. 

## How Can This Be Tested?
1) Pull down cw-filter-menu, npm start, navigate to 'Menu Items' Click 'Filter by Ingredients' 
2) Select a few ingredients, and then hit the 'Submit' button, and see which menu items match the results. 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
