### PR TITLE
Kf update tables

### DIFF
--- a/json_sample_data/seating.json
+++ b/json_sample_data/seating.json
@@ -3,60 +3,60 @@
     "table_number":1,
     "table_capacity":4,
     "firebaseKey":"-MXnzgAreqosmDOgByr1",
-    "status":true
+    "available":true
   },
   "-MXnzgAt5zG6Ewt5GIuN":{
     "table_number":2,
-    "table_capacity":3,
+    "table_capacity":4,
     "firebaseKey": "-MXnzgAt5zG6Ewt5GIuN",
-    "status":false
+    "available":true
   },
   "-MXnzgAvEi9W5qjWywCA":
   {"table_number":3,
     "table_capacity":4,
     "firebaseKey":"-MXnzgAvEi9W5qjWywCA",
-    "status":true
+    "available":true
   },
   "-MXnzgAyrgxJMb0xHGSk":{
     "table_number":4,
     "table_capacity":5,
     "firebaseKey":"-MXnzgAyrgxJMb0xHGSk",
-    "status":false
+    "available":true
   },
   "-MXnzgB1QvLFjBZHwU7G":
   {"table_number":5,
     "table_capacity":1,
     "firebaseKey":"-MXnzgB1QvLFjBZHwU7G",
-    "status":true
+    "available":true
   },
   "-MXnzgB310fKMDlShOfM":{
     "table_number":6,
-    "table_capacity":5,
+    "table_capacity":6,
     "firebaseKey":"-MXnzgB310fKMDlShOfM",
-    "status":true
+    "available":true
   },
   "-MXnzgB6TbkJ41wlCOSv":{
     "table_number":7,
-    "table_capacity":3,
+    "table_capacity":8,
     "firebaseKey":"-MXnzgB6TbkJ41wlCOSv",
-    "status":true
+    "available":true
   },
   "-MXo06IfumvDcmdoH743":{
     "table_number":8,
-    "table_capacity":3,
+    "table_capacity":10,
     "firebaseKey":"-MXo06IfumvDcmdoH743",
-    "status":false
+    "available":true
   },
   "-MXo06Ihm17zGBKSQZCj":{
     "table_number":9,
     "table_capacity":6,
     "firebaseKey": "-MXo06Ihm17zGBKSQZCj",
-    "status":false
+    "available":true
   },
   "-MXo06Ijp9m2nYc3srne":{
     "table_number":10,
     "table_capacity":4,
     "firebaseKey": "-MXo06Ijp9m2nYc3srne",
-    "status":false
+    "available":true
   }
 }

--- a/src/javascripts/components/seating/seating.js
+++ b/src/javascripts/components/seating/seating.js
@@ -6,13 +6,13 @@ const showSeating = (array) => {
   document.querySelector('#view').innerHTML = `<div id="seating-list">
   </div>`;
   array.forEach((item) => {
-    let status = 'Reserved';
-    if (item.status) {
-      status = 'Open';
+    let available = 'Available';
+    if (item.available === false) {
+      available = 'Reserved';
     }
     document.querySelector('#seating-list').innerHTML += `<div class="card" id="seating-card" style="width: 15rem;">
       <div class="card-body">
-        <p>Table ${item.table_number} is ${status}.</p>
+        <p>Table ${item.table_number} is ${available}.</p>
         <p>Total Seats: ${item.table_capacity}</p>
       </div>
     </div>`;

--- a/src/javascripts/components/seating/selectSeating.js
+++ b/src/javascripts/components/seating/selectSeating.js
@@ -10,7 +10,7 @@ const selectTable = (array = [], value) => {
     seatingArray.map((seating) => {
       if (array.includes(seating.firebaseKey)) {
         domString += `<option selected value="${seating.firebaseKey}">${seating.table_number} (Table Capacity: ${seating.table_capacity})</option>`;
-      } else {
+      } else if (seating.available) {
         domString += `<option value="${seating.firebaseKey}">${seating.table_number} (Table Capacity: ${seating.table_capacity})</option>`;
       }
       return domString;

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -40,7 +40,8 @@ import {
   deleteSeatingReservationRelationship,
   getSingleSeatingReservationInfo,
   postSeatingResData,
-  updateSeatingStatus
+  updateSeatingStatus,
+  updateSeatingStatusDelete
 } from '../helpers/data/seatingReservationsData';
 
 const domEventListeners = (e) => {
@@ -131,11 +132,9 @@ const domEventListeners = (e) => {
 
     getSingleSeatingReservationInfo(firebaseKey).then((array) => {
       const returnedArray = Object.values(array);
-      const deletedArray = returnedArray.map((obj) => deleteSeatingReservationRelationship(obj.firebaseKey));
+      const deletedArray = returnedArray.map((obj) => updateSeatingStatusDelete(obj.table_id).then(() => deleteSeatingReservationRelationship(obj.firebaseKey)));
       Promise.all(deletedArray).then((response) => console.warn(response));
-    }).then(() => postSeatingResData(seatingResObject).then());
-
-    updateSeatingStatus(seatingResObject.table_id).then((response) => console.warn(response));
+    }).then(() => updateSeatingStatus(seatingResObject.table_id).then((response) => console.warn(response)).then(() => postSeatingResData(seatingResObject).then()));
 
     const markedCheckbox = document.querySelectorAll('input[type="checkbox"]:checked');
     markedCheckbox.forEach((checkbox) => {

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -133,8 +133,8 @@ const domEventListeners = (e) => {
     getSingleSeatingReservationInfo(firebaseKey).then((array) => {
       const returnedArray = Object.values(array);
       const deletedArray = returnedArray.map((obj) => updateSeatingStatusDelete(obj.table_id).then(() => deleteSeatingReservationRelationship(obj.firebaseKey)));
-      Promise.all(deletedArray).then((response) => console.warn(response));
-    }).then(() => updateSeatingStatus(seatingResObject.table_id).then((response) => console.warn(response)).then(() => postSeatingResData(seatingResObject).then()));
+      Promise.all(deletedArray).then(() => updateSeatingStatus(seatingResObject.table_id).then(() => postSeatingResData(seatingResObject).then()));
+    });
 
     const markedCheckbox = document.querySelectorAll('input[type="checkbox"]:checked');
     markedCheckbox.forEach((checkbox) => {

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -36,7 +36,12 @@ import { printAssignedStaff, singleReservation } from '../components/reservation
 import {
   createMenuReservation, deleteMenuReservationRelationship, getIngredientsFromMenu, getSingleMenuReservationInfo
 } from '../helpers/data/menuReservationData';
-import { deleteSeatingReservationRelationship, getSingleSeatingReservationInfo, postSeatingResData } from '../helpers/data/seatingReservationsData';
+import {
+  deleteSeatingReservationRelationship,
+  getSingleSeatingReservationInfo,
+  postSeatingResData,
+  updateSeatingStatus
+} from '../helpers/data/seatingReservationsData';
 
 const domEventListeners = (e) => {
   const user = firebase.auth().currentUser;
@@ -129,6 +134,8 @@ const domEventListeners = (e) => {
       const deletedArray = returnedArray.map((obj) => deleteSeatingReservationRelationship(obj.firebaseKey));
       Promise.all(deletedArray).then((response) => console.warn(response));
     }).then(() => postSeatingResData(seatingResObject).then());
+
+    updateSeatingStatus(seatingResObject.table_id).then((response) => console.warn(response));
 
     const markedCheckbox = document.querySelectorAll('input[type="checkbox"]:checked');
     markedCheckbox.forEach((checkbox) => {

--- a/src/javascripts/events/navEvents.js
+++ b/src/javascripts/events/navEvents.js
@@ -9,7 +9,6 @@ import { getStaff } from '../helpers/data/staffData';
 import { getReservations } from '../helpers/data/reservationData';
 import { showLoginReservations } from '../components/reservations/reservations';
 import landingPage from '../views/landingPage';
-import { getFilteredTables } from '../helpers/data/seatingReservationsData';
 
 // Events for Navbar, READ only
 const navEvents = (user) => {
@@ -36,7 +35,6 @@ const navEvents = (user) => {
   document.querySelector('#nav-seating').addEventListener('click', (e) => {
     e.preventDefault();
     getSeating().then((seats) => showSeating(seats));
-    getFilteredTables(4).then((response) => console.warn(response));
   });
   // Return to landing page
   document.querySelector('#nav-home').addEventListener('click', () => {

--- a/src/javascripts/helpers/data/seatingReservationsData.js
+++ b/src/javascripts/helpers/data/seatingReservationsData.js
@@ -68,18 +68,10 @@ const updateTableRes = (firebaseKey, tableResObj) => new Promise((resolve, rejec
 });
 
 const updateSeatingStatus = (tableId) => new Promise((resolve, reject) => {
-  let body = {};
-  if (tableId) {
-    body = { available: false };
-    axios.patch(`${dbUrl}/seating/${tableId}.json`, body)
-      .then((response) => resolve(response))
-      .catch((error) => reject(error));
-  } else {
-    body = { available: true };
-    axios.patch(`${dbUrl}/seating/${tableId}.json`, body)
-      .then((response) => resolve(response))
-      .catch((error) => reject(error));
-  }
+  const body = { available: false };
+  axios.patch(`${dbUrl}/seating/${tableId}.json`, body)
+    .then((response) => resolve(response))
+    .catch((error) => reject(error));
 });
 
 const updateSeatingStatusDelete = (tableId) => new Promise((resolve, reject) => {

--- a/src/javascripts/helpers/data/seatingReservationsData.js
+++ b/src/javascripts/helpers/data/seatingReservationsData.js
@@ -74,6 +74,13 @@ const updateSeatingStatus = (tableId) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
+const updateSeatingStatusDelete = (tableId) => new Promise((resolve, reject) => {
+  const body = { available: true };
+  axios.patch(`${dbUrl}/seating/${tableId}.json`, body)
+    .then((response) => resolve(response))
+    .catch((error) => reject(error));
+});
+
 export {
   postSeatingResData,
   getSingleSeatingReservationInfo,
@@ -81,5 +88,6 @@ export {
   getFilteredTables,
   updateTableRes,
   getSeatingReservationJoin,
-  updateSeatingStatus
+  updateSeatingStatus,
+  updateSeatingStatusDelete
 };

--- a/src/javascripts/helpers/data/seatingReservationsData.js
+++ b/src/javascripts/helpers/data/seatingReservationsData.js
@@ -68,10 +68,18 @@ const updateTableRes = (firebaseKey, tableResObj) => new Promise((resolve, rejec
 });
 
 const updateSeatingStatus = (tableId) => new Promise((resolve, reject) => {
-  const body = { available: false };
-  axios.patch(`${dbUrl}/seating/${tableId}.json`, body)
-    .then((response) => resolve(response))
-    .catch((error) => reject(error));
+  let body = {};
+  if (tableId) {
+    body = { available: false };
+    axios.patch(`${dbUrl}/seating/${tableId}.json`, body)
+      .then((response) => resolve(response))
+      .catch((error) => reject(error));
+  } else {
+    body = { available: true };
+    axios.patch(`${dbUrl}/seating/${tableId}.json`, body)
+      .then((response) => resolve(response))
+      .catch((error) => reject(error));
+  }
 });
 
 const updateSeatingStatusDelete = (tableId) => new Promise((resolve, reject) => {

--- a/src/javascripts/helpers/data/seatingReservationsData.js
+++ b/src/javascripts/helpers/data/seatingReservationsData.js
@@ -43,9 +43,9 @@ const getSingleSeatingReservationInfo = (reservationId) => new Promise((resolve,
     .catch((error) => reject(error));
 });
 
-// const getSingleSeatingRes = (firebaseKey) => new Promise((resolve, reject) => {
-//   axios.get(`${dbUrl}/seating_reservations/${firebaseKey}.json`)
-//     .then((response) => resolve(response.data))
+// const getSingleSeatingReservationTableInfo = (tableId) => new Promise((resolve, reject) => {
+//   axios.get(`${dbUrl}/seating_reservations.json?orderBy="table_id"&equalTo="${tableId}"`)
+//     .then((response) => resolve(Object.values(response.data)))
 //     .catch((error) => reject(error));
 // });
 
@@ -67,11 +67,19 @@ const updateTableRes = (firebaseKey, tableResObj) => new Promise((resolve, rejec
     .catch((error) => reject(error));
 });
 
+const updateSeatingStatus = (tableId) => new Promise((resolve, reject) => {
+  const body = { available: false };
+  axios.patch(`${dbUrl}/seating/${tableId}.json`, body)
+    .then((response) => resolve(response))
+    .catch((error) => reject(error));
+});
+
 export {
   postSeatingResData,
   getSingleSeatingReservationInfo,
   deleteSeatingReservationRelationship,
   getFilteredTables,
   updateTableRes,
-  getSeatingReservationJoin
+  getSeatingReservationJoin,
+  updateSeatingStatus
 };

--- a/src/javascripts/views/landingPage.js
+++ b/src/javascripts/views/landingPage.js
@@ -1,3 +1,5 @@
+import baguetteLogo from '../../images/baguette-logo.png';
+
 const landingPage = () => {
   document.querySelector('#stage').innerHTML = '';
   document.querySelector('#modal-container').innerHTML = '';
@@ -7,7 +9,7 @@ const landingPage = () => {
       <div class="container h-100">
         <div class="row h-100 align-items-center">
           <div class="col-12 text-center">
-            <img id="landing-logo" src="src/images/baguette-logo.png">
+            <img id="landing-logo" src=${baguetteLogo} alt="page logo">
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
When a user assigns a table to a reservation, they are now only able to choose from tables that are available (i.e., not assigned to another reservation). The Seating view now shows which tables are available and which are reserved. If a user updates what table is assigned to a reservation, the previous table becomes available again and the new table is listed as reserved.

## Related Issue

## Motivation and Context
Previously, on the Seating view, the listed availability of a table was completely arbitrary. It now reflects the actual data.

## How Can This Be Tested?
git fetch
git checkout kf-update-tables

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
